### PR TITLE
Fix `read` issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # MoulinetteMC's scripts
+
 ## [`run.sh`](run.sh)
+
 ```bash
-curl https://raw.githubusercontent.com/MoulinetteMC/scripts/main/run.sh | bash 
+wget -q -O /tmp/moulinettemc.sh -- https://raw.githubusercontent.com/MoulinetteMC/scripts/main/run.sh && chmod +x /tmp/moulinettemc.sh && bash /tmp/moulinettemc.sh
 ```


### PR DESCRIPTION
As mentioned [here](https://stackoverflow.com/questions/6561072/why-wont-bash-wait-for-read-when-used-with-curl), it seems you cannot use the standard input from a `curl<> |`.

The command now does:
- download the file in `/tmp`
- make it executable
- run it